### PR TITLE
FIX: default console output formatting when both output type and emailformat  not set

### DIFF
--- a/linkedindumper.py
+++ b/linkedindumper.py
@@ -324,7 +324,7 @@ def main():
                     if mailformat:
                         print(f"{person['firstname']};{person['lastname']};{person['email']};{person['position']};{person['gender']};{person['location']};{person['profile_link']}")                        
                     else:
-                        print(";".join(person.values()))
+                        print(f"{person['firstname']};{person['lastname']};{person['position']};{person['gender']};{person['location']};{person['profile_link']}")
                 print()
 
             if args.output_json:


### PR DESCRIPTION
Error that was happening when no CSV/JSON path and no mail format is given... code tries to use ";.join()" on a dict

Just removes email from output. Okay because no email format given so email not relevant. 

Steps to reproduce original error:

```
$ python3 linkedindumper.py --url 'https://www.linkedin.com/company/venusaero' --cookie "<cookie>"

...
Progress: [########################################] 9/9

Firstname;Lastname;Position;Gender;Location;Profile
[!] Exception. Either API has changed and this script is broken or authentication failed.
    > Set 'li_at' variable permanently in script or use the '--cookie' CLI flag!
[debug] sequence item 6: expected str instance, dict found
```



